### PR TITLE
fix: load CKEditor lark theme styles

### DIFF
--- a/src/app/shared/components/ckeditor/ckeditor.component.ts
+++ b/src/app/shared/components/ckeditor/ckeditor.component.ts
@@ -2,6 +2,7 @@ import { Component, input, signal } from '@angular/core';
 
 import { CKEditorModule } from '@ckeditor/ckeditor5-angular';
 import CustomEditor from '@shared/editors/ckeditor-custom';
+import '@ckeditor/ckeditor5-theme-lark/theme/ckeditor5.css';
 
 @Component({
   selector: 'app-ckeditor',


### PR DESCRIPTION
## Summary
- import CKEditor Lark theme CSS so editor renders with proper styling

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_68b81ee85e8483229f2d60f35143c07a