### PR TITLE
feat: add jodit editor component

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@tiptap/extension-paragraph": "^3.0.9",
     "@tiptap/extension-text": "^3.0.9",
     "daisyui": "^5.0.46",
+    "jodit-angular": "^1.0.0",
     "ngx-quill": "^28.0.1",
     "postcss": "^8.5.6",
     "quill": "^2.0.3",

--- a/src/app/shared/components/jodit-editor-component/jodit-editor-component.component.html
+++ b/src/app/shared/components/jodit-editor-component/jodit-editor-component.component.html
@@ -1,0 +1,1 @@
+<jodit-angular [(ngModel)]="content"></jodit-angular>

--- a/src/app/shared/components/jodit-editor-component/jodit-editor-component.component.ts
+++ b/src/app/shared/components/jodit-editor-component/jodit-editor-component.component.ts
@@ -1,0 +1,14 @@
+import { Component } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { JoditAngularModule } from 'jodit-angular';
+
+@Component({
+  selector: 'jodit-editor-component',
+  imports: [FormsModule, JoditAngularModule],
+  templateUrl: './jodit-editor-component.component.html',
+  styleUrls: ['./jodit-editor-component.component.css'],
+})
+export class JoditEditorComponent {
+  content = '';
+}
+


### PR DESCRIPTION
## Summary
- add jodit editor component for rich text editing
- add jodit-angular dependency

## Testing
- `npm install` (fails: 403 Forbidden)
- `npm run build` (fails: Could not resolve @ckeditor/ckeditor5-theme-lark/theme/ckeditor5.css)


------
https://chatgpt.com/codex/tasks/task_e_68b834ca4f588322bc68c860659feabc