### PR TITLE
refactor: replace dialog modals with div

### DIFF
--- a/src/app/components/license-modal/license-modal.component.html
+++ b/src/app/components/license-modal/license-modal.component.html
@@ -1,15 +1,13 @@
-<dialog id="modal-license" class="modal">
-	<app-toast-message/>
-	@if(loading()){
-	<div class="overlay">
-		<span class="loading loading-spinner text-secondary"></span>
-	</div>
-	}
-	<div class="modal-box max-w-7xl">
-		<form method="dialog">
-			<button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" (click)="onClose()">✕</button>
-		</form>
-		@if (licenseData(); as license) {
+<div id="modal-license" class="modal">
+        <app-toast-message/>
+        @if(loading()){
+        <div class="overlay">
+                <span class="loading loading-spinner text-secondary"></span>
+        </div>
+        }
+        <div class="modal-box max-w-7xl">
+                <button type="button" class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" (click)="onClose()">✕</button>
+                @if (licenseData(); as license) {
 			<div class="flex justify-between items-start mt-5">
 				<div>
 					<h3 class="text-lg font-bold">{{ 'license.modal.title' | changeLanguage }}</h3>
@@ -242,4 +240,4 @@
 		}
 	</div>
 
-</dialog>
+</div>

--- a/src/app/components/license-template-modal/license-template-modal.component.html
+++ b/src/app/components/license-template-modal/license-template-modal.component.html
@@ -1,14 +1,12 @@
-<dialog id="modal-license-template" class="modal">
+<div id="modal-license-template" class="modal">
     @if(loading()){
     <div class="overlay">
         <span class="loading loading-spinner text-secondary"></span>
     </div>
     }
     <div class="modal-box max-w-7xl ">
-        <form method="dialog">
-            <button type="button" class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
+        <button type="button" class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2"
                 (click)="onClose()">✕</button>
-        </form>
 
         <form [formGroup]="templateForm" (ngSubmit)="onSubmit()">
             <div class="flex justify-between items-center mb-4 mt-5">
@@ -65,6 +63,7 @@
             </div>
         </form>
     </div>
-</dialog>
+</div>
+
 
 

--- a/src/app/components/license-terms-modal/license-terms-modal.component.html
+++ b/src/app/components/license-terms-modal/license-terms-modal.component.html
@@ -1,15 +1,13 @@
-<dialog id="modal-license-terms" class="modal">
+<div id="modal-license-terms" class="modal">
     <app-toast-message/>
 
     @if(loading()){
-		<div class="overlay">
-		  <span class="loading loading-spinner text-secondary"></span>
-		</div>
-	}
+                <div class="overlay">
+                  <span class="loading loading-spinner text-secondary"></span>
+                </div>
+        }
     <div class="modal-box max-w-7xl">
-        <form method="dialog">
-            <button type="button" class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" (click)="onClose()">✕</button>
-        </form>
+        <button type="button" class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2" (click)="onClose()">✕</button>
 
         <form [formGroup]="termsForm" (ngSubmit)="onSubmit()">
             <div class="flex justify-between items-center mb-4 mt-5">
@@ -96,4 +94,4 @@
             </div>
         </form>
     </div>
-</dialog>
+</div>

--- a/src/app/services/modal.service.ts
+++ b/src/app/services/modal.service.ts
@@ -6,18 +6,20 @@ import { Injectable } from '@angular/core';
 export class ModalService {
 
   open(id: string): void {
-    const modal = document.getElementById(id) as HTMLDialogElement;
+    const modal = document.getElementById(id) as HTMLDivElement;
     const overlay = document.getElementById('modal-overlay') as HTMLDivElement;
-    modal?.showModal();
+
     if (modal) {
+      modal.classList.add('modal-open');
       overlay.classList.remove('overlay-hidden');
     }
   }
 
   close(id: string): void {
-    const modal = document.getElementById(id) as HTMLDialogElement;
+    const modal = document.getElementById(id) as HTMLDivElement;
     const overlay = document.getElementById('modal-overlay') as HTMLDivElement;
-    modal?.close();
+
+    modal?.classList.remove('modal-open');
     overlay.classList.add('overlay-hidden');
   }
 


### PR DESCRIPTION
## Summary
- replace `<dialog>` elements with `<div>` modals
- toggle modal visibility via `modal-open` class in service

## Testing
- `npm run build -- --configuration development`


------
https://chatgpt.com/codex/tasks/task_e_68b98fa6cd608322a72cd4a517945e0a