### PR TITLE
Refactor terms table modal handling

### DIFF
--- a/src/app/components/table-list/terms-conditions-table/terms-conditions-table.component.html
+++ b/src/app/components/table-list/terms-conditions-table/terms-conditions-table.component.html
@@ -70,4 +70,3 @@
         </tbody>
     </table>
 </div>
-<app-license-terms-modal [inputData]="selectedTerm()" (closed)="clearSelectedTerm($event)" />

--- a/src/app/pages/terms-conditions/terms-conditions.component.html
+++ b/src/app/pages/terms-conditions/terms-conditions.component.html
@@ -18,7 +18,10 @@
         }
         <!--  -->
         @if (termsResource.hasValue()){
-        <app-terms-conditions-table [termResponse]="termsResource.value()" [openModal]="openModal()" (closedModal)="closedModal($event)" />
+        <app-terms-conditions-table
+            [termResponse]="termsResource.value()"
+            (termSelected)="selectTermFromTable($event)"
+            [updatedTerm]="updatedTerm()" />
         }
     </div>
     @if (termsResource.hasValue()) {
@@ -26,3 +29,6 @@
     }
     }
 </div>
+<app-license-terms-modal
+    [inputData]="selectedTerm()"
+    (closed)="onModalClosed($event)" />

--- a/src/app/pages/terms-conditions/terms-conditions.component.ts
+++ b/src/app/pages/terms-conditions/terms-conditions.component.ts
@@ -11,27 +11,27 @@ import { ChangeLanguagePipe } from "@pipes/change-language.pipe";
 import { TermsConditionsService } from "@services/terms-conditions.service";
 import { TermsAndConditions } from "@interfaces/terms-conditions.interface";
 import { LoaderService } from "@services/loader.service";
+import { ModalService } from "@services/modal.service";
+import { LicenseTermsModalComponent } from "@components/license-terms-modal/license-terms-modal.component";
 
 @Component({
   selector: 'app-terms-conditions',
-  imports: [SkeletonComponent, PaginationComponent, TermsConditionsTableComponent, ChangeLanguagePipe],
+  imports: [SkeletonComponent, PaginationComponent, TermsConditionsTableComponent, ChangeLanguagePipe, LicenseTermsModalComponent],
   templateUrl: './terms-conditions.component.html',
 })
-export default class TermsConditionsComponent { 
-
-  // loaderService = inject(LoaderService);
+export default class TermsConditionsComponent {
   localeService = inject(LocaleService);
   loaderService = inject(LoaderService);
   termsService = inject(TermsConditionsService);
   paginationService = inject(PaginationService);
+  modalService = inject(ModalService);
 
   routeTitle = inject(ActivatedRoute).snapshot.routeConfig?.path || '';
 
-  // terms = signal<LicenseTerm[]>([]);
   selectedTerm = signal<TermsAndConditions | null>(null);
+  updatedTerm = signal<TermsAndConditions | null>(null);
   loading = signal(false);
-  pageTitle = computed( () => this.localeService.getCurrentTitle(this.routeTitle));
-  openModal = signal(false);
+  pageTitle = computed(() => this.localeService.getCurrentTitle(this.routeTitle));
 
   termsResource = rxResource({
     params: () => ({ page: this.paginationService.currentPage() }),
@@ -44,12 +44,19 @@ export default class TermsConditionsComponent {
     },
   });
 
-  openModalNewTerm(){
-    this.openModal.set(true);
+  openModalNewTerm() {
+    this.selectedTerm.set(null);
+    this.modalService.open('modal-license-terms');
   }
 
-  closedModal(event: boolean){
-    this.openModal.set(false);
+  selectTermFromTable(term: TermsAndConditions) {
+    this.selectedTerm.set(term);
+    this.modalService.open('modal-license-terms');
+  }
+
+  onModalClosed(updated: TermsAndConditions) {
+    this.updatedTerm.set(null);
+    this.updatedTerm.set(updated);
   }
 
   // newTerm(term: TermsAndConditions) {
@@ -61,3 +68,4 @@ export default class TermsConditionsComponent {
   // }
 
 }
+


### PR DESCRIPTION
## Summary
- decouple terms table from modal and emit term selection
- handle modal open/close in terms conditions page
- pass updates to terms table via signal instead of `ViewChild`

## Testing
- `npm test --silent -- --watch=false` *(fails: npm: command not found)*
- `apt-get update >/tmp/apt.log` *(fails: 403 Forbidden repository access)*

------
https://chatgpt.com/codex/tasks/task_e_68b9986f35b08322bedcf13f72220672