### PR TITLE
refactor: externalize license modal from table component

### DIFF
--- a/src/app/components/table-list/licenses-table/licenses-table.component.html
+++ b/src/app/components/table-list/licenses-table/licenses-table.component.html
@@ -59,6 +59,3 @@
         </tbody>
     </table>
 </div>
-@if(selectedLicense()){
-<app-license-modal [licenseData]="selectedLicense()" (closed)="clearSelectedLicense($event)" />
-}

--- a/src/app/pages/licenses/licenses.component.html
+++ b/src/app/pages/licenses/licenses.component.html
@@ -23,7 +23,8 @@
 
         @if (licensesResource.hasValue()){
 
-        <app-licenses-table [licenseResponse]="licensesResource.value()" (selectionChanged)="selectedLicenses.set($event)" />
+        <app-licenses-table [licenseResponse]="licensesResource.value()" [updatedLicense]="updatedLicense()"
+            (selectionChanged)="selectedLicenses.set($event)" (licenseSelected)="selectLicenseFromTable($event)" />
         }
 
     </div>
@@ -34,3 +35,5 @@
 
     }
 </div>
+<app-license-modal [licenseData]="selectedLicense()" (closed)="onModalClosed($event)" />
+

--- a/src/app/pages/licenses/licenses.component.ts
+++ b/src/app/pages/licenses/licenses.component.ts
@@ -5,16 +5,17 @@ import { ActivatedRoute } from "@angular/router";
 import { License } from "@interfaces/license.interface";
 import { LicenseService } from "@services/licenses.service";
 import { LicensesTableComponent } from "@components/table-list/licenses-table/licenses-table.component";
-import { LoaderComponent } from "@components/loader/loader.component";
 import { LocaleService } from "@services/locale.service";
 import { PaginationComponent } from "@components/pagination/pagination.component";
 import { PaginationService } from "@components/pagination/pagination.service";
 import { SkeletonComponent } from "@components/skeleton/skeleton.component";
 import { ChangeLanguagePipe } from "@pipes/change-language.pipe";
+import { LicenseModalComponent } from "@components/license-modal/license-modal.component";
+import { ModalService } from "@services/modal.service";
 
 @Component({
   selector: 'app-licenses',
-  imports: [SkeletonComponent, PaginationComponent, LicensesTableComponent, ChangeLanguagePipe],
+  imports: [SkeletonComponent, PaginationComponent, LicensesTableComponent, ChangeLanguagePipe, LicenseModalComponent],
   templateUrl: './licenses.component.html',
 })
 export default class LicensesComponent {
@@ -22,12 +23,15 @@ export default class LicensesComponent {
   licenseService = inject(LicenseService);
   routeTitle = inject(ActivatedRoute).snapshot.routeConfig?.path || '';
   paginationService = inject(PaginationService);
+  modalService = inject(ModalService);
+
   selectedLicenses = signal<License[]>([]);
+  selectedLicense = signal<License | null>(null);
+  updatedLicense = signal<License | null>(null);
 
   loading = signal(false);
   licenses = signal<License[]>([]);
-  pageTitle = computed( () => this.localeService.getCurrentTitle(this.routeTitle));
-  
+  pageTitle = computed(() => this.localeService.getCurrentTitle(this.routeTitle));
 
   licensesResource = rxResource({
     params: () => ({ page: this.paginationService.currentPage() }),
@@ -39,19 +43,13 @@ export default class LicensesComponent {
     },
   });
 
-  // showModal(license: License) {
-  //   this.selectedLicense.set(license);
-  //   // Esperar un tick para que el modal se renderice
-  //   setTimeout(() => {
-  //     const modal = document.getElementById(
-  //       'modal-license'
-  //     ) as HTMLDialogElement;
-  //     if (modal) modal.showModal();
-  //   }, 1);
-  // }
+  selectLicenseFromTable(license: License) {
+    this.selectedLicense.set(license);
+    this.modalService.open('modal-license');
+  }
 
-  // onModalClosed() {
-  //   console.log('Hola');
-  //   this.selectedLicense.set(null); // limpiar si necesitas
-  // }
+  onModalClosed(updated: License) {
+    this.updatedLicense.set(null);
+    this.updatedLicense.set(updated);
+  }
 }


### PR DESCRIPTION
## Summary
- move license modal management into LicensesComponent
- simplify LicensesTableComponent to emit selected license and accept updates

## Testing
- `npm test -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b9a969f8d48322b5bf13bcce8d3660