### PR TITLE
refactor: manage license template modal in general settings

### DIFF
--- a/src/app/components/table-list/license-template-table/license-template-table.component.html
+++ b/src/app/components/table-list/license-template-table/license-template-table.component.html
@@ -49,6 +49,3 @@
         </tbody>
     </table>
 </div>
-@if(selectedTemplate()){
-<app-license-template-modal [inputData]="selectedTemplate()" (closed)="clearSelectedTemplate($event)" />
-}

--- a/src/app/components/table-list/license-template-table/license-template-table.component.ts
+++ b/src/app/components/table-list/license-template-table/license-template-table.component.ts
@@ -1,42 +1,52 @@
-import { Component, effect, inject, input, linkedSignal, signal } from '@angular/core';
+import { Component, effect, inject, input, linkedSignal, output } from '@angular/core';
 import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
-import { LicenseTemplateModalComponent } from '@components/license-template-modal/license-template-modal.component';
 import { ApiLicenseTemplateResponse, LicenseTemplate } from '@interfaces/license-template.interface';
 import { ChangeLanguagePipe } from '@pipes/change-language.pipe';
-import { ModalService } from '@services/modal.service';
 
 @Component({
   selector: 'app-license-template-table',
-  imports: [ChangeLanguagePipe, LicenseTemplateModalComponent],
+  imports: [ChangeLanguagePipe],
   templateUrl: './license-template-table.component.html',
 })
 export class LicenseTemplateTableComponent {
-  
   sanitizer = inject(DomSanitizer);
-  modalService = inject(ModalService);
 
   licenseTemplateData = input.required<ApiLicenseTemplateResponse>();
+  updatedTemplate = input<LicenseTemplate | null>();
+
   licenseTemplates = linkedSignal(() => this.licenseTemplateData().data as LicenseTemplate[]);
-  openModal = signal(false);
-  selectedTemplate = signal<LicenseTemplate | null>(null);
 
-  modalEffect = effect(() => {
+  templateSelected = output<LicenseTemplate>();
+  newTemplate = output<void>();
 
-    if (this.openModal()) {
-      this.selectedTemplate.set(null);
-    }
-    
-    const licenseTemplate = this.selectedTemplate();
-    
-    if (licenseTemplate || this.openModal()) {
-      setTimeout(() => {
-        this.modalService.open('modal-license-template');
-      }, 500);
-    }
-  });
+  constructor() {
+    effect(() => {
+      const templateInformation = this.updatedTemplate();
+      if (templateInformation) {
+        this.updateTemplateList(templateInformation);
+      }
+    });
+  }
 
   selectTemplate(template: LicenseTemplate) {
-    this.selectedTemplate.set(template);
+    this.templateSelected.emit(template);
+  }
+
+  openModalNewLicenseTemplate() {
+    this.newTemplate.emit();
+  }
+
+  private updateTemplateList(templateInformation: LicenseTemplate) {
+    this.licenseTemplates.update((current) => {
+      const index = current.findIndex((term) => term.id === templateInformation.id);
+
+      if (index >= 0) {
+        current[index] = { ...current[index], ...templateInformation };
+        return [...current];
+      } else {
+        return [...current, templateInformation];
+      }
+    });
   }
 
   getActive(active: number) {
@@ -52,30 +62,5 @@ export class LicenseTemplateTableComponent {
     const sliceTerm = textTerm.slice(0, 100) + (textTerm.length > 100 ? '...' : '');
 
     return this.sanitizer.bypassSecurityTrustHtml(sliceTerm);
-  }
-
-  clearSelectedTemplate(templateInformation: LicenseTemplate) {
-  
-      if (templateInformation) {
-  
-        this.licenseTemplates.update((current) => {
-  
-          const index = current.findIndex((term) => term.id === templateInformation.id);
-  
-          if (index >= 0) {
-            current[index] = { ...current[index], ...templateInformation };
-            return [...current];
-          } else {
-            return [...current, templateInformation];
-          }
-        });
-      }
-      
-      this.selectedTemplate.set(null);
-    }
-
-
-  openModalNewLicenseTemplate(){
-    this.modalService.open('modal-license-template');
   }
 }

--- a/src/app/pages/general-settings/general-settings.component.html
+++ b/src/app/pages/general-settings/general-settings.component.html
@@ -24,7 +24,11 @@
                     </div>
                 }
                 @if (licensesTemplateResource.hasValue()){
-                    <app-license-template-table [licenseTemplateData]="licensesTemplateResource.value()" />
+                    <app-license-template-table
+                        [licenseTemplateData]="licensesTemplateResource.value()"
+                        [updatedTemplate]="updatedTemplate()"
+                        (templateSelected)="selectTemplateFromTable($event)"
+                        (newTemplate)="openModalNewTemplate()" />
                 }
             </div>
             @if (licensesTemplateResource.hasValue()) {
@@ -36,3 +40,4 @@
     }
 
 </div>
+<app-license-template-modal [inputData]="selectedTemplate()" (closed)="onModalClosed($event)" />

--- a/src/app/pages/general-settings/general-settings.component.ts
+++ b/src/app/pages/general-settings/general-settings.component.ts
@@ -1,7 +1,6 @@
 import { Component, computed, inject, signal } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 
-import { License } from "@interfaces/license.interface";
 import { LoaderService } from "@services/loader.service";
 import { LocaleService } from "@services/locale.service";
 import { SkeletonComponent } from "@components/skeleton/skeleton.component";
@@ -11,25 +10,36 @@ import { rxResource } from "@angular/core/rxjs-interop";
 import { PaginationService } from "@components/pagination/pagination.service";
 import { LicenseTemplateService } from "@services/license-templates.service";
 import { PaginationComponent } from "@components/pagination/pagination.component";
+import { LicenseTemplateModalComponent } from "@components/license-template-modal/license-template-modal.component";
+import { LicenseTemplate } from "@interfaces/license-template.interface";
+import { ModalService } from "@services/modal.service";
 
 
 @Component({
   selector: 'app-general-settings',
-  imports: [SkeletonComponent, LicenseTemplateTableComponent, ChangeLanguagePipe, PaginationComponent],
+  imports: [
+    SkeletonComponent,
+    LicenseTemplateTableComponent,
+    ChangeLanguagePipe,
+    PaginationComponent,
+    LicenseTemplateModalComponent,
+  ],
   templateUrl: './general-settings.component.html',
 })
-export default class GeneralSettingsComponent { 
+export default class GeneralSettingsComponent {
 
   paginationService = inject(PaginationService);
   licenseTemplateService = inject(LicenseTemplateService);
   localeService = inject(LocaleService);
   loaderService = inject(LoaderService);
+  modalService = inject(ModalService);
   routeTitle = inject(ActivatedRoute).snapshot.routeConfig?.path || '';
-  
-  loading = signal(true);
-  licenses = signal<License[]>([]);
-  pageTitle = computed( () => this.localeService.getCurrentTitle(this.routeTitle));
 
+  loading = signal(true);
+  pageTitle = computed(() => this.localeService.getCurrentTitle(this.routeTitle));
+
+  selectedTemplate = signal<LicenseTemplate | null>(null);
+  updatedTemplate = signal<LicenseTemplate | null>(null);
 
   licensesTemplateResource = rxResource({
     params: () => ({ page: this.paginationService.currentPage() }),
@@ -42,11 +52,24 @@ export default class GeneralSettingsComponent {
   });
 
 
-  constructor(){
+  constructor() {
     setTimeout(() => {
-      this.loading.set(false)
+      this.loading.set(false);
     }, 500);
-
   }
 
- }
+  selectTemplateFromTable(template: LicenseTemplate) {
+    this.selectedTemplate.set(template);
+    this.modalService.open('modal-license-template');
+  }
+
+  openModalNewTemplate() {
+    this.selectedTemplate.set(null);
+    this.modalService.open('modal-license-template');
+  }
+
+  onModalClosed(template: LicenseTemplate) {
+    this.updatedTemplate.set(null);
+    this.updatedTemplate.set(template);
+  }
+}


### PR DESCRIPTION
## Summary
- emit template selection and creation events from license template table
- render license template modal in general settings page and handle updates

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: No binary for ChromeHeadless)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ab48cce883228e7240c26cfd9dfc