### PR TITLE
feat: toggle logo input with label

### DIFF
--- a/src/app/components/license-template-modal/license-template-modal.component.html
+++ b/src/app/components/license-template-modal/license-template-modal.component.html
@@ -44,9 +44,16 @@
                     <legend class="fieldset-legend" [class.input-error]="isInvalid('logo')">
                         {{ 'license_template.table.logo' | changeLanguage }}
                     </legend>
-                    <input type="file" class="file-input grow w-full"
+                    @if(!templateForm.get('logo')?.value) {
+                    <input type="file" class="file-input grow w-full" (change)="onLogoSelected($event)" formControlName="logo"
                         [placeholder]="'license_template.table.logo' | changeLanguage"
                         [class.input-error]="isInvalid('logo')" />
+                    } @else {
+                    <div class="flex items-center gap-2">
+                        <span>{{ getLogoName() }}</span>
+                        <button type="button" class="btn btn-xs btn-circle btn-ghost" (click)="removeLogo()">✕</button>
+                    </div>
+                    }
                     <form-error-label [control]="templateForm.get('logo')!" />
                 </fieldset>
             </div>

--- a/src/app/components/license-template-modal/license-template-modal.component.ts
+++ b/src/app/components/license-template-modal/license-template-modal.component.ts
@@ -141,12 +141,27 @@ export class LicenseTemplateModalComponent {
       return firstValueFrom(this.licenseTemplateService.createTermsAndConditions(template));
     }
   
-    // Actualizar término existente
-    private async updateTerm(templateId: number, template: LicenseTemplate) {
-      return firstValueFrom(this.licenseTemplateService.updateTermsAndConditions(templateId, template));
-    }
+  // Actualizar término existente
+  private async updateTerm(templateId: number, template: LicenseTemplate) {
+    return firstValueFrom(this.licenseTemplateService.updateTermsAndConditions(templateId, template));
+  }
 
-  
+  onLogoSelected(event: Event) {
+    const file = (event.target as HTMLInputElement).files?.[0];
+    if (file) {
+      this.templateForm.get('logo')?.setValue(file.name);
+      this.templateForm.get('logo')?.markAsTouched();
+    }
+  }
+
+  getLogoName(): string {
+    return this.templateForm.get('logo')?.value || '';
+  }
+
+  removeLogo() {
+    this.templateForm.get('logo')?.setValue('');
+  }
+
   onClose() {
     this.modalService.close('modal-license-template');
     this.closed.emit(this.templateData()!);


### PR DESCRIPTION
## Summary
- toggle license template logo between file input and label with remove option

## Testing
- `npm test --silent -- --watch=false` *(fails: No binary for Chrome browser on your platform)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ad600c588322b7e6ef5dd7185058